### PR TITLE
pipeline.r integrity check

### DIFF
--- a/pipeline.r
+++ b/pipeline.r
@@ -161,6 +161,9 @@ readyBasecalling <- function(Run_folders_WithRTA,subFoldersFull,config,bclVersio
                           col.names=F,row.names=F,append=T,quote=F)
               shellBCLs[p] <- gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName)
               p <- p+1
+          }else{
+            # in the current version, if the shell script exists, no shellBCLs will be generated
+            message("shell script ",gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName)," already exists.")
           }
         #####################################################################
         }

--- a/pipeline.r
+++ b/pipeline.r
@@ -35,130 +35,138 @@ readyBasecalling <- function(Run_folders_WithRTA,subFoldersFull,config,bclVersio
         message("Read samplesheet ",basename(sampleSheetName)," discovered for run ",currentRun)
         index1Lengths <- unlist(lapply(ss$Index,function(x)nchar(x)))
         # (5) check whether there is "Index2" column in the sample sheet
-        if(any(colnames(ss) %in% "Index2")){
-            ss$Index2 <- gsub(" ","",ss$Index2)
-            index2Lengths <- unlist(lapply(ss$Index2,function(x)nchar(x)))
-            index2NAs <- unlist(lapply(ss$Index2,function(x)is.na(x)))
-            index2Lengths[index2NAs] <- 0
-            allIndexTypes <- paste0(index1Lengths,"-",index2Lengths)
-            uniqueIndexTypes <- unique(allIndexTypes)
-            #ss$SampleID <- gsub("[[:punct:]]", "_", ss$SampleID).)
-            #ss$SampleID <- gsub("[^[:alnum:]]", "_", ss$SampleID).)
-            ss$Index <- gsub("-NA|-$|^-$","",paste(ss$Index,ss$Index2,sep="-"))
-            # after merging Index2 information to Index, delete the Index2 column from ss
-            ss <- ss[,-grep("Index2",colnames(ss))]
-        }else{
-            allIndexTypes <- paste0(index1Lengths)
-            uniqueIndexTypes <- unique(allIndexTypes)
-            #ss$SampleID <- gsub("[[:punct:]]", "_", ss$SampleID).)
-            #ss$SampleID <- gsub("[^[:alnum:]]", "_", ss$SampleID).)
-        }
+            # if yes, merge the Index2 information to Index
+            if(any(colnames(ss) %in% "Index2")){
+                ss$Index2 <- gsub(" ","",ss$Index2)
+                index2Lengths <- unlist(lapply(ss$Index2,function(x)nchar(x)))
+                index2NAs <- unlist(lapply(ss$Index2,function(x)is.na(x)))
+                index2Lengths[index2NAs] <- 0
+                allIndexTypes <- paste0(index1Lengths,"-",index2Lengths)
+                uniqueIndexTypes <- unique(allIndexTypes)
+                #ss$SampleID <- gsub("[[:punct:]]", "_", ss$SampleID).)
+                #ss$SampleID <- gsub("[^[:alnum:]]", "_", ss$SampleID).)
+                ss$Index <- gsub("-NA|-$|^-$","",paste(ss$Index,ss$Index2,sep="-"))
+                # after merging Index2 information to Index, delete the Index2 column from ss
+                ss <- ss[,-grep("Index2",colnames(ss))]
+            }else{
+                allIndexTypes <- paste0(index1Lengths)
+                uniqueIndexTypes <- unique(allIndexTypes)
+                #ss$SampleID <- gsub("[[:punct:]]", "_", ss$SampleID).)
+                #ss$SampleID <- gsub("[^[:alnum:]]", "_", ss$SampleID).)
+            }
+        
         indexLoop <- 1  # unused parameter; for future development
+        
+        # (6) generate sample sheets and shell scripts for different index length combination
         for(l in uniqueIndexTypes){
             tempss <- ss[allIndexTypes %in% l,]
-            tempss[is.na(tempss)] <- ""
+            tempss[is.na(tempss)] <- ""  # remove NA from the data.frame
+            # check integrity of sample sheet, make sure it has 10 columns
             if(!ncol(tempss) > 9){
               diff <- 10-ncol(tempss)
               addColumns <- matrix(nrow=nrow(tempss),ncol=diff)
               colnames(addColumns) <- paste0("Dummy",seq(1,diff))
               tempss <- cbind(tempss,addColumns)
             }
-          
-          
+          # generate new sample sheets #################################
           if(!file.exists(gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName))){
-            if(bclVersion == "old"){
-              write.table(tempss,file=gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),quote=F,sep=",",row.names=F,col.names=T)
-            }else{
-              Sample_Project <- tempss$Project
-              Lane <- tempss$Lane
-              Sample_ID <- tempss$SampleID
-              Sample_Name <- tempss$SampleID
-              index <- tempss$Index
-              if(any(grepl("-",index))){
-                indexMat <- matrix(unlist(strsplit(tempss$Index,"-")),ncol=2,byrow=T)
-                index <- indexMat[,1]
-                index2 <- indexMat[,2]
-                tempss_New <- cbind(Sample_Project,Lane,Sample_ID,Sample_Name,index,index2)
-              }else{
-                tempss_New <- cbind(Sample_Project,Lane,Sample_ID,Sample_Name,index)
+              if(bclVersion == "old"){  # generate sample sheet for the old version of bclVersion
+                write.table(tempss,file=gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),quote=F,sep=",",row.names=F,col.names=T)
+              }else{  # generate sample sheet for the new version of bclVersion
+                Sample_Project <- tempss$Project
+                Lane <- tempss$Lane
+                Sample_ID <- tempss$SampleID
+                Sample_Name <- tempss$SampleID
+                index <- tempss$Index
+                if(any(grepl("-",index))){
+                  indexMat <- matrix(unlist(strsplit(tempss$Index,"-")),ncol=2,byrow=T)
+                  index <- indexMat[,1]
+                  index2 <- indexMat[,2]
+                  tempss_New <- cbind(Sample_Project,Lane,Sample_ID,Sample_Name,index,index2)
+                }else{
+                  tempss_New <- cbind(Sample_Project,Lane,Sample_ID,Sample_Name,index)
+                }
+                dataSectionString <- "[Data]"
+                write.table(dataSectionString,file=gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),quote=F,sep=",",row.names=F,col.names=F)
+                write.table(tempss_New,file=gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),quote=F,sep=",",row.names=F,col.names=T,append=T)
               }
-              dataSectionString <- "[Data]"
-              write.table(dataSectionString,file=gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),quote=F,sep=",",row.names=F,col.names=F)
-              write.table(tempss_New,file=gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),quote=F,sep=",",row.names=F,col.names=T,append=T)
-            }
           }
-        #if(!dir.exists(gsub("\\.csv",paste0("_",l),sampleSheetName))){
-        #  dir.create(gsub("\\.csv",paste0("_",l),sampleSheetName),showWarnings = F)
-        #}
+          ##################################################################
+          #if(!dir.exists(gsub("\\.csv",paste0("_",l),sampleSheetName))){
+          #  dir.create(gsub("\\.csv",paste0("_",l),sampleSheetName),showWarnings = F)
+          #}
+        # generate shell script for qsub ####################################################################
         if(!file.exists(gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName))){
-          indexLengths <- unlist(strsplit(l,"-"))
-          if(as.numeric(as.vector(currentRunParameters$IndexRead1)) != 0){
-            numberOfNs <- as.numeric(as.vector(currentRunParameters$IndexRead1)) - as.numeric(indexLengths[1])
-            if(indexLengths[1] == 0){
-              indexMask1 <- ",n*"
+            indexLengths <- unlist(strsplit(l,"-"))  # this is for the dual-index situation, i.e. l="6-0"
+            # define the parameters for "--use-base-mask" ################################################
+              # a. define the parameter for IndexRead1: indexMask1
+              if(as.numeric(as.vector(currentRunParameters$IndexRead1)) != 0){
+                  numberOfNs <- as.numeric(as.vector(currentRunParameters$IndexRead1)) - as.numeric(indexLengths[1])
+                  if(indexLengths[1] == 0){
+                    indexMask1 <- ",n*"
+                  }else{
+                    indexMask1 <-  paste0(",I",indexLengths[1],paste0(rep("n",numberOfNs),collapse=""))
+                  }
+              }else{
+                  indexMask1 <- ""
+              }
+              # b. define the parameter for IndexRead2: indexMask2
+              if(as.numeric(as.vector(currentRunParameters$IndexRead2)) != 0){
+                  if (length(indexLengths)==1){
+                    indexLengths[2]=0
+                  }
+                  numberOfNs <- as.numeric(as.vector(currentRunParameters$IndexRead2)) - as.numeric(indexLengths[2])
+                  if(indexLengths[2] == 0){
+                    indexMask2 <- ",n*"
+                  }else{
+                    indexMask2 <-  paste0(",I",indexLengths[2],paste0(rep("n",numberOfNs),collapse=""))
+                  }
+              }else{
+                  indexMask2 <- ""
+              }
+              # c. define the parameter for single end or paired end
+              if(currentRunParameters$Read2 > 0){  # paired end
+                  usebasemask <- paste0("y*n",indexMask1,indexMask2,",y*n")
+              }else{     # single end
+                  usebasemask <- paste0("y*n",indexMask1,indexMask2)
+              }
+            #######################################################################################################
+            if(bclVersion == "Old"){
+                programToRun <- as.vector(config[config$section == "programs" & config$name == "configureBclToFastq","value"])
+                runBCLcommand <- paste0(
+                          programToRun,
+                          " --input-dir ",
+                          file.path(currentRun,as.vector(config[config$section == "paths" & config$name == "inputdir","value"])),
+                          " --sample-sheet ",
+                          gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),
+                          " --fastq-cluster-count=0 --use-bases-mask ",usebasemask,
+                          " --output-dir ",
+                          gsub("\\.csv",paste0("_",l),sampleSheetName),
+                          "\n")
             }else{
-              indexMask1 <-  paste0(",I",indexLengths[1],paste0(rep("n",numberOfNs),collapse=""))
+                programToRun <- as.vector(config[config$section == "programs" & config$name == "BclToFastq2","value"])
+                runBCLcommand <- paste0(
+                          programToRun,
+                          " --input-dir ",
+                          file.path(currentRun,as.vector(config[config$section == "paths" & config$name == "inputdir","value"])),
+                          " --sample-sheet ",
+                          gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),
+                          " --use-bases-mask ",usebasemask,
+                          " -r 4 -p 4 -w 4 -d 4 --output-dir ",
+                          gsub("\\.csv",paste0("_",l),sampleSheetName),
+                          "\n")
             }
-          }else{
-            indexMask1 <- ""
-          }
-          if(as.numeric(as.vector(currentRunParameters$IndexRead2)) != 0){
-            numberOfNs <- as.numeric(as.vector(currentRunParameters$IndexRead2)) - as.numeric(indexLengths[2])
-            if(indexLengths[2] == 0){
-              indexMask2 <- ",n*"
-            }else{
-              indexMask2 <-  paste0(",I",indexLengths[2],paste0(rep("n",numberOfNs),collapse=""))
-            }
-          }else{
-            indexMask2 <- ""
-          }
-          if(currentRunParameters$Read2 > 0){
-            usebasemask <- paste0("y*n",indexMask1,indexMask2,",y*n")
+          
+          
+            write.table("#!/bin/bash",file=gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName),col.names=F,row.names=F,append=F,quote=F)
+            write.table(runBCLcommand,file=gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName),col.names=F,row.names=F,append=T,quote=F)
+            write.table("#!/bin/bash",file=gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName),col.names=F,row.names=F,append=F,quote=F)
+            write.table(paste0("",gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName)),
+                        file=gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName),
+                        col.names=F,row.names=F,append=T,quote=F)
             
-          }else{
-            usebasemask <- paste0("y*n",indexMask1,indexMask2)
-          }
-          
-          if(bclVersion == "Old"){
-            programToRun <- as.vector(config[config$section == "programs" & config$name == "configureBclToFastq","value"])
-            runBCLcommand <- paste0(
-              programToRun,
-              " --input-dir ",
-              file.path(currentRun,as.vector(config[config$section == "paths" & config$name == "inputdir","value"])),
-              " --sample-sheet ",
-              gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),
-              " --fastq-cluster-count=0 --use-bases-mask ",usebasemask
-              ,
-              " --output-dir ",
-              gsub("\\.csv",paste0("_",l),sampleSheetName),
-              "\n"
-            )
-          }else{
-            programToRun <- as.vector(config[config$section == "programs" & config$name == "BclToFastq2","value"])
-            runBCLcommand <- paste0(
-              programToRun,
-              " --input-dir ",
-              file.path(currentRun,as.vector(config[config$section == "paths" & config$name == "inputdir","value"])),
-              " --sample-sheet ",
-              gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),
-              " --use-bases-mask ",usebasemask
-              ,
-              " -r 4 -p 4 -w 4 -d 4 --output-dir ",
-              gsub("\\.csv",paste0("_",l),sampleSheetName),
-              "\n"
-            )
-          }
-          
-          
-          write.table("#!/bin/bash",file=gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName),col.names=F,row.names=F,append=F,quote=F)
-          write.table(runBCLcommand,file=gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName),col.names=F,row.names=F,append=T,quote=F)
-          write.table("#!/bin/bash",file=gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName),col.names=F,row.names=F,append=F,quote=F)
-          write.table(paste0("",gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName)),
-                      file=gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName),
-                      col.names=F,row.names=F,append=T,quote=F)
-          
-          shellBCLs[p] <- gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName)
-          p <- p+1
+            shellBCLs[p] <- gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName)
+            p <- p+1
         }
       }
     }else{

--- a/pipeline.r
+++ b/pipeline.r
@@ -22,7 +22,6 @@ readyBasecalling <- function(Run_folders_WithRTA,subFoldersFull,config,bclVersio
         # (2) check Project integrity
             # "UP": Unknown project
             ss[ss$Project==""|ss$Project==" "|is.na(ss$Project),]$Project<-"UP"
-            
         # (3) a. check the index sequence in $Index column, i.e. remove the space character
             ss$Index <- gsub(" ","",ss$Index)
             # b. check the index sequence length in $Index column
@@ -54,9 +53,7 @@ readyBasecalling <- function(Run_folders_WithRTA,subFoldersFull,config,bclVersio
                 #ss$SampleID <- gsub("[[:punct:]]", "_", ss$SampleID).)
                 #ss$SampleID <- gsub("[^[:alnum:]]", "_", ss$SampleID).)
             }
-        
         indexLoop <- 1  # unused parameter; for future development
-        
         # (6) generate sample sheets and shell scripts for different index length combination
         for(l in uniqueIndexTypes){
             tempss <- ss[allIndexTypes %in% l,]
@@ -96,81 +93,78 @@ readyBasecalling <- function(Run_folders_WithRTA,subFoldersFull,config,bclVersio
           #  dir.create(gsub("\\.csv",paste0("_",l),sampleSheetName),showWarnings = F)
           #}
         # generate shell script for qsub ####################################################################
-        if(!file.exists(gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName))){
-            indexLengths <- unlist(strsplit(l,"-"))  # this is for the dual-index situation, i.e. l="6-0"
-            # define the parameters for "--use-base-mask" ################################################
-              # a. define the parameter for IndexRead1: indexMask1
-              if(as.numeric(as.vector(currentRunParameters$IndexRead1)) != 0){
-                  numberOfNs <- as.numeric(as.vector(currentRunParameters$IndexRead1)) - as.numeric(indexLengths[1])
-                  if(indexLengths[1] == 0){
-                    indexMask1 <- ",n*"
-                  }else{
-                    indexMask1 <-  paste0(",I",indexLengths[1],paste0(rep("n",numberOfNs),collapse=""))
-                  }
+          if(!file.exists(gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName))){
+              indexLengths <- unlist(strsplit(l,"-"))  # this is for the dual-index situation, i.e. l="6-0"
+              # define the parameters for "--use-base-mask" ################################################
+                # a. define the parameter for IndexRead1: indexMask1
+                if(as.numeric(as.vector(currentRunParameters$IndexRead1)) != 0){
+                    numberOfNs <- as.numeric(as.vector(currentRunParameters$IndexRead1)) - as.numeric(indexLengths[1])
+                    if(indexLengths[1] == 0){
+                      indexMask1 <- ",n*"
+                    }else{
+                      indexMask1 <-  paste0(",I",indexLengths[1],paste0(rep("n",numberOfNs),collapse=""))
+                    }
+                }else{
+                    indexMask1 <- ""
+                }
+                # b. define the parameter for IndexRead2: indexMask2
+                if(as.numeric(as.vector(currentRunParameters$IndexRead2)) != 0){
+                    if (length(indexLengths)==1){
+                      indexLengths[2]=0
+                    }
+                    numberOfNs <- as.numeric(as.vector(currentRunParameters$IndexRead2)) - as.numeric(indexLengths[2])
+                    if(indexLengths[2] == 0){
+                      indexMask2 <- ",n*"
+                    }else{
+                      indexMask2 <-  paste0(",I",indexLengths[2],paste0(rep("n",numberOfNs),collapse=""))
+                    }
+                }else{
+                    indexMask2 <- ""
+                }
+                # c. define the parameter for single end or paired end
+                if(currentRunParameters$Read2 > 0){  # paired end
+                    usebasemask <- paste0("y*n",indexMask1,indexMask2,",y*n")
+                }else{     # single end
+                    usebasemask <- paste0("y*n",indexMask1,indexMask2)
+                }
+             # define the script for the analysis
+              if(bclVersion == "Old"){
+                  programToRun <- as.vector(config[config$section == "programs" & config$name == "configureBclToFastq","value"])
+                  runBCLcommand <- paste0(
+                            programToRun,
+                            " --input-dir ",
+                            file.path(currentRun,as.vector(config[config$section == "paths" & config$name == "inputdir","value"])),
+                            " --sample-sheet ",
+                            gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),
+                            " --fastq-cluster-count=0 --use-bases-mask ",usebasemask,
+                            " --output-dir ",
+                            gsub("\\.csv",paste0("_",l),sampleSheetName),
+                            "\n")
               }else{
-                  indexMask1 <- ""
+                  programToRun <- as.vector(config[config$section == "programs" & config$name == "BclToFastq2","value"])
+                  runBCLcommand <- paste0(
+                            programToRun,
+                            " --input-dir ",
+                            file.path(currentRun,as.vector(config[config$section == "paths" & config$name == "inputdir","value"])),
+                            " --sample-sheet ",
+                            gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),
+                            " --use-bases-mask ",usebasemask,
+                            " -r 4 -p 4 -w 4 -d 4 --output-dir ",
+                            gsub("\\.csv",paste0("_",l),sampleSheetName),
+                            "\n")
               }
-              # b. define the parameter for IndexRead2: indexMask2
-              if(as.numeric(as.vector(currentRunParameters$IndexRead2)) != 0){
-                  if (length(indexLengths)==1){
-                    indexLengths[2]=0
-                  }
-                  numberOfNs <- as.numeric(as.vector(currentRunParameters$IndexRead2)) - as.numeric(indexLengths[2])
-                  if(indexLengths[2] == 0){
-                    indexMask2 <- ",n*"
-                  }else{
-                    indexMask2 <-  paste0(",I",indexLengths[2],paste0(rep("n",numberOfNs),collapse=""))
-                  }
-              }else{
-                  indexMask2 <- ""
-              }
-              # c. define the parameter for single end or paired end
-              if(currentRunParameters$Read2 > 0){  # paired end
-                  usebasemask <- paste0("y*n",indexMask1,indexMask2,",y*n")
-              }else{     # single end
-                  usebasemask <- paste0("y*n",indexMask1,indexMask2)
-              }
-            #######################################################################################################
-            if(bclVersion == "Old"){
-                programToRun <- as.vector(config[config$section == "programs" & config$name == "configureBclToFastq","value"])
-                runBCLcommand <- paste0(
-                          programToRun,
-                          " --input-dir ",
-                          file.path(currentRun,as.vector(config[config$section == "paths" & config$name == "inputdir","value"])),
-                          " --sample-sheet ",
-                          gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),
-                          " --fastq-cluster-count=0 --use-bases-mask ",usebasemask,
-                          " --output-dir ",
-                          gsub("\\.csv",paste0("_",l),sampleSheetName),
-                          "\n")
-            }else{
-                programToRun <- as.vector(config[config$section == "programs" & config$name == "BclToFastq2","value"])
-                runBCLcommand <- paste0(
-                          programToRun,
-                          " --input-dir ",
-                          file.path(currentRun,as.vector(config[config$section == "paths" & config$name == "inputdir","value"])),
-                          " --sample-sheet ",
-                          gsub("\\.csv",paste0("_",l,"\\.csv"),sampleSheetName),
-                          " --use-bases-mask ",usebasemask,
-                          " -r 4 -p 4 -w 4 -d 4 --output-dir ",
-                          gsub("\\.csv",paste0("_",l),sampleSheetName),
-                          "\n")
-            }
-          
-          
-            write.table("#!/bin/bash",file=gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName),col.names=F,row.names=F,append=F,quote=F)
-            write.table(runBCLcommand,file=gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName),col.names=F,row.names=F,append=T,quote=F)
-            write.table("#!/bin/bash",file=gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName),col.names=F,row.names=F,append=F,quote=F)
-            write.table(paste0("",gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName)),
-                        file=gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName),
-                        col.names=F,row.names=F,append=T,quote=F)
-            
-            shellBCLs[p] <- gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName)
-            p <- p+1
+              write.table("#!/bin/bash",file=gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName),col.names=F,row.names=F,append=F,quote=F)
+              write.table(runBCLcommand,file=gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName),col.names=F,row.names=F,append=T,quote=F)
+              write.table("#!/bin/bash",file=gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName),col.names=F,row.names=F,append=F,quote=F)
+              write.table(paste0("",gsub("\\.csv",paste0("_",l,"\\.sh"),sampleSheetName)),
+                          file=gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName),
+                          col.names=F,row.names=F,append=T,quote=F)
+              shellBCLs[p] <- gsub("\\.csv",paste0("_",l,"ForQSUB\\.sh"),sampleSheetName)
+              p <- p+1
+          }
+        #####################################################################
         }
-      }
     }else{
-      
       stop("No samplesheet ",basename(sampleSheetName)," discovered for run ",basename(currentRun))
     }
   }
@@ -203,7 +197,7 @@ p <- 1
 
 
 bclcommands <- readyBasecalling(Run_folders_WithRTA,subFoldersFull,config,bclVersion="New")
-qsubscommands <- makeQsubs(bclcommands,launch=TRUE)
+qsubscommands <- makeQsubs(bclcommands,launch=F)
 
 qsubscommands
 shellBCLs


### PR DESCRIPTION
(1) add comments in the script
(2) check sample sheet integrity
a. check Project integrity
b. check the index sequence length in $Index column and fixed the script for trimming long index
c. fix indexLengths 
d. change the way constructs "shellBCLs[p]" and no need to claim "p" anymore
e. in the current version, if the shell script exists, no shellBCLs will be generated. Add a message to remind the user if the shell script already exits.